### PR TITLE
Add color knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ const defaultValue = 78;
 const value = number(label, defaultValue);
 ```
 
+### color
+
+Allows you to get a color from the user.
+
+```js
+const label = 'Color';
+const defaultValue = '#ff00ff';
+
+const value = color(label, defaultValue);
+```
+
 ### object
 
 Allows you to get a JSON object from the user.

--- a/dist/components/types/Color.js
+++ b/dist/components/types/Color.js
@@ -1,0 +1,92 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var styles = {
+  display: 'table-cell',
+  boxSizing: 'border-box',
+  verticalAlign: 'middle',
+  height: '26px',
+  width: '100%',
+  outline: 'none',
+  border: '1px solid #f7f4f4',
+  borderRadius: 2,
+  fontSize: 11,
+  color: '#444',
+  backgroundColor: 'white'
+};
+
+var ColorType = function (_React$Component) {
+  (0, _inherits3.default)(ColorType, _React$Component);
+
+  function ColorType() {
+    (0, _classCallCheck3.default)(this, ColorType);
+    return (0, _possibleConstructorReturn3.default)(this, (ColorType.__proto__ || (0, _getPrototypeOf2.default)(ColorType)).apply(this, arguments));
+  }
+
+  (0, _createClass3.default)(ColorType, [{
+    key: 'render',
+    value: function render() {
+      var _this2 = this;
+
+      var _props = this.props,
+          knob = _props.knob,
+          _onChange = _props.onChange;
+
+
+      return _react2.default.createElement('input', {
+        id: knob.name,
+        style: styles,
+        value: knob.value,
+        type: 'color',
+        onChange: function onChange(e) {
+          return _onChange(e.target.value);
+        }
+      });
+    }
+  }]);
+  return ColorType;
+}(_react2.default.Component);
+
+ColorType.propTypes = {
+  knob: _react2.default.PropTypes.object,
+  onChange: _react2.default.PropTypes.func
+};
+
+ColorType.serialize = function (value) {
+  return value;
+};
+
+ColorType.deserialize = function (value) {
+  return value;
+};
+
+exports.default = ColorType;

--- a/dist/components/types/index.js
+++ b/dist/components/types/index.js
@@ -12,6 +12,10 @@ var _Number = require('./Number');
 
 var _Number2 = _interopRequireDefault(_Number);
 
+var _Color = require('./Color');
+
+var _Color2 = _interopRequireDefault(_Color);
+
 var _Boolean = require('./Boolean');
 
 var _Boolean2 = _interopRequireDefault(_Boolean);
@@ -37,6 +41,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 exports.default = {
   text: _Text2.default,
   number: _Number2.default,
+  color: _Color2.default,
   boolean: _Boolean2.default,
   object: _Object2.default,
   select: _Select2.default,

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,6 +7,7 @@ exports.knob = knob;
 exports.text = text;
 exports.boolean = boolean;
 exports.number = number;
+exports.color = color;
 exports.object = object;
 exports.select = select;
 exports.array = array;
@@ -39,6 +40,10 @@ function boolean(name, value) {
 
 function number(name, value) {
   return manager.knob(name, { type: 'number', value: value });
+}
+
+function color(name, value) {
+  return manager.knob(name, { type: 'color', value: value });
 }
 
 function object(name, value) {

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -26,7 +26,7 @@ stories.add('with all knobs', () => {
   const dob = date('DOB', new Date('January 20 1887'));
 
   const bold = boolean('Bold', false);
-  const color = color('Color', 'black');
+  const textColor = color('Color', 'black');
   const textDecoration = select('Decoration', {
     none: 'None',
     underline: 'Underline',
@@ -43,7 +43,7 @@ stories.add('with all knobs', () => {
   const style = {
     ...customStyle,
     fontWeight: bold ? 800: 400,
-    color,
+    color: textColor,
     textDecoration
   };
 

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -4,7 +4,6 @@ import moment from 'moment';
 import {
   withKnobs,
   number,
-  color,
   object,
   boolean,
   text,
@@ -26,12 +25,11 @@ stories.add('with all knobs', () => {
   const dob = date('DOB', new Date('January 20 1887'));
 
   const bold = boolean('Bold', false);
-  const textColor = color('Color', 'black');
-  const textDecoration = select('Decoration', {
-    none: 'None',
-    underline: 'Underline',
-    "line-through": 'Line-Through'
-  }, 'none');
+  const color = select('Color', {
+    red: 'Red',
+    green: 'Green',
+    black: 'Black'
+  }, 'black');
 
   const passions = array('Passions', ['Fishing', 'Skiing']);
 
@@ -43,8 +41,7 @@ stories.add('with all knobs', () => {
   const style = {
     ...customStyle,
     fontWeight: bold ? 800: 400,
-    color: textColor,
-    textDecoration
+    color
   };
 
   return (
@@ -53,7 +50,7 @@ stories.add('with all knobs', () => {
       I like: <ul>{passions.map((p, i) => <li key={i}>{p}</li>)}</ul>
     </div>
   );
-});
+})
 
 stories.add('dates Knob', () => {
   const today = date('today');
@@ -85,10 +82,10 @@ stories.add('dates Knob', () => {
       </li>
     </ul>
   )
-});
+})
 
 stories.add('dynamic knobs', () => {
-  const showOptional = select('Show optional', ['yes', 'no'], 'yes');
+  const showOptional = select('Show optional', ['yes', 'no'], 'yes')
   return (
     <div>
       <div>
@@ -97,7 +94,7 @@ stories.add('dynamic knobs', () => {
       { showOptional==='yes' ? <div>{text('optional', 'I can disapear')}</div> : null }
     </div>
   )
-});
+})
 
 stories.add('without any knob', () => (
   <button>This is a button</button>

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 import {
   withKnobs,
   number,
+  color,
   object,
   boolean,
   text,
@@ -25,11 +26,12 @@ stories.add('with all knobs', () => {
   const dob = date('DOB', new Date('January 20 1887'));
 
   const bold = boolean('Bold', false);
-  const color = select('Color', {
-    red: 'Red',
-    green: 'Green',
-    black: 'Black'
-  }, 'black');
+  const color = color('Color', 'black');
+  const textDecoration = select('Decoration', {
+    none: 'None',
+    underline: 'Underline',
+    "line-through": 'Line-Through'
+  }, 'none');
 
   const passions = array('Passions', ['Fishing', 'Skiing']);
 
@@ -41,7 +43,8 @@ stories.add('with all knobs', () => {
   const style = {
     ...customStyle,
     fontWeight: bold ? 800: 400,
-    color
+    color,
+    textDecoration
   };
 
   return (
@@ -50,7 +53,7 @@ stories.add('with all knobs', () => {
       I like: <ul>{passions.map((p, i) => <li key={i}>{p}</li>)}</ul>
     </div>
   );
-})
+});
 
 stories.add('dates Knob', () => {
   const today = date('today');
@@ -82,10 +85,10 @@ stories.add('dates Knob', () => {
       </li>
     </ul>
   )
-})
+});
 
 stories.add('dynamic knobs', () => {
-  const showOptional = select('Show optional', ['yes', 'no'], 'yes')
+  const showOptional = select('Show optional', ['yes', 'no'], 'yes');
   return (
     <div>
       <div>
@@ -94,7 +97,7 @@ stories.add('dynamic knobs', () => {
       { showOptional==='yes' ? <div>{text('optional', 'I can disapear')}</div> : null }
     </div>
   )
-})
+});
 
 stories.add('without any knob', () => (
   <button>This is a button</button>

--- a/example/typescript/index.tsx
+++ b/example/typescript/index.tsx
@@ -4,6 +4,7 @@ import * as moment from 'moment';
 import {
   withKnobs,
   number,
+  color,
   object,
   boolean,
   text,
@@ -24,11 +25,12 @@ stories.add('with all knobs', () => {
   const dob = date('DOB', new Date('January 20 1887'));
 
   const bold = boolean('Bold', false);
-  const color = select('Color', {
-    red: 'Red',
-    green: 'Green',
-    black: 'Black'
-  }, 'black');
+  const color = color('Color', 'black');
+  const textDecoration = select('Decoration', {
+    none: 'None',
+    underline: 'Underline',
+    "line-through": 'Line-Through'
+  }, 'none');
 
   const customStyle = object('Style', {
     fontFamily: 'Arial',
@@ -37,7 +39,8 @@ stories.add('with all knobs', () => {
 
   const style = Object.assign({}, customStyle, {
     fontWeight: bold ? 800: 400,
-    color
+    color,
+    textDecoration
   });
 
   return (
@@ -45,7 +48,7 @@ stories.add('with all knobs', () => {
       I'm {name} and I was born on "{moment(dob).format("DD MMM YYYY")}"
     </div>
   );
-})
+});
 
 stories.add('dates Knob', () => {
   const today = date('today');
@@ -77,7 +80,7 @@ stories.add('dates Knob', () => {
       </li>
     </ul>
   )
-})
+});
 
 stories.add('dynamic knobs', () => {
   const showOptional = select('Show optional', ['yes', 'no'], 'yes')
@@ -89,7 +92,7 @@ stories.add('dynamic knobs', () => {
       { showOptional==='yes' ? <div>{text('optional', 'I can disapear')}</div> : null }
     </div>
   )
-})
+});
 
 stories.add('without any knob', () => (
   <button>This is a button</button>

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "deep-equal": "^1.0.1",
     "insert-css": "^1.0.0",
     "moment": "^2.15.0",
+    "react-color": "^2.4.3",
     "react-datetime": "^2.6.0",
     "react-textarea-autosize": "^4.0.5"
   },

--- a/src/components/types/Color.js
+++ b/src/components/types/Color.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+const styles = {
+  display: 'table-cell',
+  boxSizing: 'border-box',
+  verticalAlign: 'middle',
+  height: '26px',
+  width: '100%',
+  outline: 'none',
+  border: '1px solid #f7f4f4',
+  borderRadius: 2,
+  fontSize: 11,
+  color: '#444',
+  backgroundColor: 'white'
+};
+
+class ColorType extends React.Component {
+  render() {
+    const { knob, onChange } = this.props;
+
+    return (
+      <input
+        id={knob.name}
+        style={styles}
+        value={knob.value}
+        type="color"
+        onChange={e => onChange(e.target.value)}
+      />
+    );
+  }
+}
+
+ColorType.propTypes = {
+  knob: React.PropTypes.object,
+  onChange: React.PropTypes.func,
+};
+
+ColorType.serialize = function (value) {
+  return value;
+};
+
+ColorType.deserialize = function (value) {
+  return value;
+};
+
+export default ColorType;

--- a/src/components/types/Color.js
+++ b/src/components/types/Color.js
@@ -6,20 +6,14 @@ const styles = {
     padding: '5px',
     background: '#fff',
     borderRadius: '1px',
-    boxShadow: '0 0 0 1px rgba(0,0,0,.1)',
+    border: '1px solid rgb(247, 244, 244)',
     display: 'inline-block',
     cursor: 'pointer',
   },
   popover: {
     position: 'absolute',
-    right: 0,
-  },
-  modal: {
-    position: 'absolute',
     top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
+    right: 0,
     zIndex: '2',
   },
   cover: {
@@ -31,45 +25,74 @@ const styles = {
   },
 };
 
-const triggerClassName = 'color-picker-switch';
-
 class ColorType extends React.Component {
   constructor(props) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
-    this.handleClose = this.handleClose.bind(this);
+    this.onMouseDown = this.onMouseDown.bind(this);
+    this.onMouseUp = this.onMouseUp.bind(this);
+    this.onWindowMouseDown = this.onWindowMouseDown.bind(this);
+    this.mouseDownInColorPicker = false;
     this.state = {
       displayColorPicker: false,
     };
   }
 
-  handleClick() {
-    this.setState({ displayColorPicker: !this.state.displayColorPicker });
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.displayColorPicker != prevState.displayColorPicker) {
+      document[this.state.displayColorPicker
+        ? "addEventListener"
+        : "removeEventListener"]('mousedown', this.onWindowMouseDown);
+      document[this.state.displayColorPicker
+        ? "addEventListener"
+        : "removeEventListener"]('touchstart', this.onWindowMouseDown);
+    }
+  }
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.onWindowMouseDown);
+    document.removeEventListener('touchstart', this.onWindowMouseDown);
   }
 
-  handleClose(e) {
-    if (e.target.className !== triggerClassName) return;
-    this.setState({ displayColorPicker: false });
+  onWindowMouseDown() {
+    if (this.mouseIsDownOnCalendar) {
+      return;
+    }
+    this.setState({
+      displayColorPicker: false
+    });
+  }
+
+  onMouseDown() {
+    this.mouseDownInColorPicker = true;
+  }
+
+  onMouseUp() {
+    this.mouseDownInColorPicker = false;
+  }
+
+  handleClick() {
+    this.mouseDownInColorPicker = true;
+    this.setState({
+      displayColorPicker: !this.state.displayColorPicker
+    });
   }
 
   render() {
     const { knob, onChange } = this.props;
     const colorStyle = {
-      width: '36px',
+      width: '300px',
       height: '14px',
       borderRadius: '2px',
       background: knob.value,
     };
     return (
       <div id={knob.name}>
-        <div style={ styles.swatch } onClick={ this.handleClick } className={triggerClassName}>
+        <div style={ styles.swatch } onClick={ this.handleClick }>
           <div style={ colorStyle } />
         </div>
         { this.state.displayColorPicker ? (
-          <div style={ styles.modal } onClick={ this.handleClose } className={triggerClassName}>
-            <div style={ styles.popover }>
-              <SketchPicker color={ knob.value } onChange={ color => onChange(color.hex) } />
-            </div>
+          <div style={ styles.popover } onMouseDown={this.onMouseDown} onMouseUp={this.onMouseUp}>
+            <SketchPicker color={ knob.value } onChange={ color => onChange(color.hex) } />
           </div>
         ) : null }
       </div>

--- a/src/components/types/Color.js
+++ b/src/components/types/Color.js
@@ -39,13 +39,13 @@ class ColorType extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.state.displayColorPicker != prevState.displayColorPicker) {
+    if (this.state.displayColorPicker !== prevState.displayColorPicker) {
       document[this.state.displayColorPicker
-        ? "addEventListener"
-        : "removeEventListener"]('mousedown', this.onWindowMouseDown);
+        ? 'addEventListener'
+        : 'removeEventListener']('mousedown', this.onWindowMouseDown);
       document[this.state.displayColorPicker
-        ? "addEventListener"
-        : "removeEventListener"]('touchstart', this.onWindowMouseDown);
+        ? 'addEventListener'
+        : 'removeEventListener']('touchstart', this.onWindowMouseDown);
     }
   }
   componentWillUnmount() {
@@ -58,7 +58,7 @@ class ColorType extends React.Component {
       return;
     }
     this.setState({
-      displayColorPicker: false
+      displayColorPicker: false,
     });
   }
 
@@ -73,7 +73,7 @@ class ColorType extends React.Component {
   handleClick() {
     this.mouseDownInColorPicker = true;
     this.setState({
-      displayColorPicker: !this.state.displayColorPicker
+      displayColorPicker: !this.state.displayColorPicker,
     });
   }
 

--- a/src/components/types/Color.js
+++ b/src/components/types/Color.js
@@ -1,31 +1,78 @@
 import React from 'react';
+import { SketchPicker } from 'react-color';
 
 const styles = {
-  display: 'table-cell',
-  boxSizing: 'border-box',
-  verticalAlign: 'middle',
-  height: '26px',
-  width: '100%',
-  outline: 'none',
-  border: '1px solid #f7f4f4',
-  borderRadius: 2,
-  fontSize: 11,
-  color: '#444',
-  backgroundColor: 'white'
+  swatch: {
+    padding: '5px',
+    background: '#fff',
+    borderRadius: '1px',
+    boxShadow: '0 0 0 1px rgba(0,0,0,.1)',
+    display: 'inline-block',
+    cursor: 'pointer',
+  },
+  popover: {
+    position: 'absolute',
+    right: 0,
+  },
+  modal: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    zIndex: '2',
+  },
+  cover: {
+    position: 'fixed',
+    top: '0px',
+    right: '0px',
+    bottom: '0px',
+    left: '0px',
+  },
 };
 
+const triggerClassName = 'color-picker-switch';
+
 class ColorType extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+    this.state = {
+      displayColorPicker: false,
+    };
+  }
+
+  handleClick() {
+    this.setState({ displayColorPicker: !this.state.displayColorPicker });
+  }
+
+  handleClose(e) {
+    if (e.target.className !== triggerClassName) return;
+    this.setState({ displayColorPicker: false });
+  }
+
   render() {
     const { knob, onChange } = this.props;
-
+    const colorStyle = {
+      width: '36px',
+      height: '14px',
+      borderRadius: '2px',
+      background: knob.value,
+    };
     return (
-      <input
-        id={knob.name}
-        style={styles}
-        value={knob.value}
-        type="color"
-        onChange={e => onChange(e.target.value)}
-      />
+      <div id={knob.name}>
+        <div style={ styles.swatch } onClick={ this.handleClick } className={triggerClassName}>
+          <div style={ colorStyle } />
+        </div>
+        { this.state.displayColorPicker ? (
+          <div style={ styles.modal } onClick={ this.handleClose } className={triggerClassName}>
+            <div style={ styles.popover }>
+              <SketchPicker color={ knob.value } onChange={ color => onChange(color.hex) } />
+            </div>
+          </div>
+        ) : null }
+      </div>
     );
   }
 }

--- a/src/components/types/index.js
+++ b/src/components/types/index.js
@@ -1,5 +1,6 @@
 import TextType from './Text';
 import NumberType from './Number';
+import ColorType from './Color';
 import BooleanType from './Boolean';
 import ObjectType from './Object';
 import SelectType from './Select';
@@ -9,6 +10,7 @@ import DateType from './Date';
 export default {
   text: TextType,
   number: NumberType,
+  color: ColorType,
   boolean: BooleanType,
   object: ObjectType,
   select: SelectType,

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,10 @@ export function number(name, value) {
   return manager.knob(name, { type: 'number', value });
 }
 
+export function color(name, value) {
+  return manager.knob(name, { type: 'color', value });
+}
+
 export function object(name, value) {
   return manager.knob(name, { type: 'object', value });
 }

--- a/storybook-addon-knobs.d.ts
+++ b/storybook-addon-knobs.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 interface KnobOption<T> {
 	value: T,
-	type: 'text' | 'boolean' | 'number' | 'object' | 'select' | 'date',
+	type: 'text' | 'boolean' | 'number' | 'color' | 'object' | 'select' | 'date',
 }
 
 interface StoryContext {
@@ -17,6 +17,8 @@ export function text(name: string, value: string | null): string;
 export function boolean(name: string, value: boolean): boolean;
 
 export function number(name: string, value: number): number;
+
+export function color(name: string, value: number): number;
 
 export function object<T>(name: string, value: T): T;
 


### PR DESCRIPTION
![color-type-knob](https://cloud.githubusercontent.com/assets/1045347/20339875/70bbd744-abe7-11e6-9cfb-8c5242d21c07.png)

Add a color picker.
This is a presentational plugin and should support a basic presentation switch which is the color.
now supported by all browsers, and until now was used in a select instead of using the native color picker.

Based on 'number', and as such, was inserted right after it in all the code appearances.