### PR TITLE
Update the *.d.ts file "array" and "select" knobs

### DIFF
--- a/storybook-addon-knobs.d.ts
+++ b/storybook-addon-knobs.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 interface KnobOption<T> {
 	value: T,
-	type: 'text' | 'boolean' | 'number' | 'color' | 'object' | 'select' | 'date',
+	type: 'text' | 'boolean' | 'number' | 'color' | 'object' | 'array' | 'select' | 'date',
 }
 
 interface StoryContext {
@@ -23,7 +23,9 @@ export function color(name: string, value: string): string;
 export function object<T>(name: string, value: T): T;
 
 export function select<T>(name: string, options: { [s: string]: T }, value: string): T;
-export function select(name: string, options: string[], value: string): string;
+export function select<T>(name: string, options: T[], value: T): T;
+
+export function array<T>(name: string, value: T[], separator: string): T[];
 
 export function date(name: string, value?: Date): Date;
 


### PR DESCRIPTION
"array" knob is available to use, but it's not available for export.
"select" knob is updated to work with any kind of types (strings, numbers).