### PR TITLE
Fixing performance issues

### DIFF
--- a/dist/KnobManager.js
+++ b/dist/KnobManager.js
@@ -103,11 +103,11 @@ var KnobManager = function () {
         return;
       }
       this.calling = true;
-
+      var timestamp = +new Date();
       setTimeout(function () {
         _this.calling = false;
         // emit to the channel and trigger a panel re-render
-        _this.channel.emit('addon:knobs:setKnobs', _this.knobStore.getAll());
+        _this.channel.emit('addon:knobs:setKnobs', { knobs: _this.knobStore.getAll(), timestamp: timestamp });
       }, PANEL_UPDATE_INTERVAL);
     }
   }]);

--- a/dist/components/Panel.js
+++ b/dist/components/Panel.js
@@ -44,6 +44,10 @@ var _types = require('./types');
 
 var _types2 = _interopRequireDefault(_types);
 
+var _lodash = require('lodash.debounce');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var styles = {
@@ -89,14 +93,28 @@ var Panel = function (_React$Component) {
     _this.handleChange = _this.handleChange.bind(_this);
     _this.setKnobs = _this.setKnobs.bind(_this);
     _this.reset = _this.reset.bind(_this);
+    _this.setOptions = _this.setOptions.bind(_this);
 
     _this.state = { knobs: {} };
     _this.loadedFromUrl = false;
     _this.props.channel.on('addon:knobs:setKnobs', _this.setKnobs);
+    _this.props.channel.on('addon:knobs:setOptions', _this.setOptions);
+
     return _this;
   }
 
   (0, _createClass3.default)(Panel, [{
+    key: 'setOptions',
+    value: function setOptions() {
+      var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
+        debounce: false,
+        leading: false };
+
+      if (options.debounce) {
+        this.emitChange = (0, _lodash2.default)(this.emitChange, 450, { leading: options.leading });
+      }
+    }
+  }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       this.props.channel.removeListener('addon:knobs:setKnobs', this.setKnobs);
@@ -138,6 +156,11 @@ var Panel = function (_React$Component) {
       this.props.channel.emit('addon:knobs:reset');
     }
   }, {
+    key: 'emitChange',
+    value: function emitChange(changedKnob) {
+      this.props.channel.emit('addon:knobs:knobChange', changedKnob);
+    }
+  }, {
     key: 'handleChange',
     value: function handleChange(changedKnob) {
       var _props2 = this.props,
@@ -157,7 +180,8 @@ var Panel = function (_React$Component) {
       queryParams['knob-' + name] = _types2.default[type].serialize(value);
 
       api.setQueryParams(queryParams);
-      channel.emit('addon:knobs:knobChange', changedKnob);
+
+      this.emitChange(changedKnob);
     }
   }, {
     key: 'render',

--- a/dist/components/Panel.js
+++ b/dist/components/Panel.js
@@ -139,7 +139,6 @@ var Panel = function (_React$Component) {
 
 
       if (this.lastEdit <= timestamp) {
-        this.lastEdit = getTimestamp();
 
         (0, _keys2.default)(knobs).forEach(function (name) {
           var knob = knobs[name];

--- a/dist/components/Panel.js
+++ b/dist/components/Panel.js
@@ -100,6 +100,7 @@ var Panel = function (_React$Component) {
     _this.setOptions = _this.setOptions.bind(_this);
 
     _this.state = { knobs: {} };
+    _this.options = {};
 
     _this.lastEdit = getTimestamp();
     _this.loadedFromUrl = false;
@@ -118,8 +119,10 @@ var Panel = function (_React$Component) {
     value: function setOptions() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {
         debounce: false,
-        leading: false };
+        timestamps: false
+      };
 
+      this.options = options;
       if (options.debounce) {
         this.emitChange = (0, _lodash2.default)(this.emitChange, options.debounce.wait, { leading: options.debounce.leading });
       }
@@ -138,8 +141,7 @@ var Panel = function (_React$Component) {
           channel = _props.channel;
 
 
-      if (this.lastEdit <= timestamp) {
-
+      if (!this.options.timestamps || this.lastEdit <= timestamp) {
         (0, _keys2.default)(knobs).forEach(function (name) {
           var knob = knobs[name];
           // For the first time, get values from the URL and set them.

--- a/dist/components/Panel.js
+++ b/dist/components/Panel.js
@@ -111,7 +111,7 @@ var Panel = function (_React$Component) {
         leading: false };
 
       if (options.debounce) {
-        this.emitChange = (0, _lodash2.default)(this.emitChange, 450, { leading: options.leading });
+        this.emitChange = (0, _lodash2.default)(this.emitChange, options.debounce, { leading: options.leading });
       }
     }
   }, {

--- a/dist/components/Panel.js
+++ b/dist/components/Panel.js
@@ -141,7 +141,7 @@ var Panel = function (_React$Component) {
           channel = _props.channel;
 
 
-      if (!this.options.timestamps || this.lastEdit <= timestamp) {
+      if (!this.options.timestamps || !timestamp || this.lastEdit <= timestamp) {
         (0, _keys2.default)(knobs).forEach(function (name) {
           var knob = knobs[name];
           // For the first time, get values from the URL and set them.

--- a/dist/components/PropField.js
+++ b/dist/components/PropField.js
@@ -36,6 +36,10 @@ var _types = require('./types');
 
 var _types2 = _interopRequireDefault(_types);
 
+var _lodash = require('lodash.isequal');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var InvalidType = function InvalidType() {
@@ -74,29 +78,32 @@ stylesheet.checkbox = (0, _extends3.default)({}, stylesheet.input, {
   width: 'auto'
 });
 
-var PropField = function (_React$Component) {
-  (0, _inherits3.default)(PropField, _React$Component);
+var PropField = function (_React$PureComponent) {
+  (0, _inherits3.default)(PropField, _React$PureComponent);
 
   function PropField(props) {
     (0, _classCallCheck3.default)(this, PropField);
 
     var _this = (0, _possibleConstructorReturn3.default)(this, (PropField.__proto__ || (0, _getPrototypeOf2.default)(PropField)).call(this, props));
 
-    _this._onChange = _this.onChange.bind(_this);
+    _this._onChange = _this._onChange.bind(_this);
     return _this;
   }
 
   (0, _createClass3.default)(PropField, [{
-    key: 'onChange',
-    value: function onChange(e) {
-      this.props.onChange(e.target.value);
+    key: '_onChange',
+    value: function _onChange(value) {
+      this.props.onChange(this.props.name, this.props.type, value);
+    }
+  }, {
+    key: 'shouldComponentUpdate',
+    value: function shouldComponentUpdate(newProps) {
+      return !(0, _lodash2.default)(this.props.knob, newProps.knob);
     }
   }, {
     key: 'render',
     value: function render() {
-      var _props = this.props,
-          onChange = _props.onChange,
-          knob = _props.knob;
+      var knob = this.props.knob;
 
 
       var InputType = _types2.default[knob.type] || InvalidType;
@@ -111,13 +118,13 @@ var PropField = function (_React$Component) {
         ),
         _react2.default.createElement(InputType, {
           knob: knob,
-          onChange: onChange
+          onChange: this._onChange
         })
       );
     }
   }]);
   return PropField;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 exports.default = PropField;
 

--- a/dist/components/PropForm.js
+++ b/dist/components/PropForm.js
@@ -45,8 +45,8 @@ var stylesheet = {
   }
 };
 
-var propForm = function (_React$Component) {
-  (0, _inherits3.default)(propForm, _React$Component);
+var propForm = function (_React$PureComponent) {
+  (0, _inherits3.default)(propForm, _React$PureComponent);
 
   function propForm() {
     (0, _classCallCheck3.default)(this, propForm);
@@ -70,6 +70,7 @@ var propForm = function (_React$Component) {
 
       var knobs = this.props.knobs;
 
+
       return _react2.default.createElement(
         'form',
         { style: stylesheet.propForm },
@@ -80,14 +81,14 @@ var propForm = function (_React$Component) {
             type: knob.type,
             value: knob.value,
             knob: knob,
-            onChange: _this2._onFieldChange.bind(null, knob.name, knob.type)
+            onChange: _this2._onFieldChange
           });
         })
       );
     }
   }]);
   return propForm;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 exports.default = propForm;
 

--- a/dist/components/WrapStory.js
+++ b/dist/components/WrapStory.js
@@ -78,7 +78,7 @@ var WrapStory = function (_React$Component) {
           channel = _props.channel,
           knobStore = _props.knobStore;
 
-      channel.emit('addon:knobs:setKnobs', knobStore.getAll());
+      channel.emit('addon:knobs:setKnobs', { knobs: knobStore.getAll(), timestamp: +new Date() });
     }
   }, {
     key: 'knobChanged',

--- a/dist/components/WrapStory.js
+++ b/dist/components/WrapStory.js
@@ -74,11 +74,12 @@ var WrapStory = function (_React$Component) {
   }, {
     key: 'setPaneKnobs',
     value: function setPaneKnobs() {
+      var timestamp = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : +new Date();
       var _props = this.props,
           channel = _props.channel,
           knobStore = _props.knobStore;
 
-      channel.emit('addon:knobs:setKnobs', { knobs: knobStore.getAll(), timestamp: +new Date() });
+      channel.emit('addon:knobs:setKnobs', { knobs: knobStore.getAll(), timestamp: timestamp });
     }
   }, {
     key: 'knobChanged',
@@ -106,7 +107,7 @@ var WrapStory = function (_React$Component) {
 
       knobStore.reset();
       this.setState({ storyContent: storyFn(context) });
-      this.setPaneKnobs();
+      this.setPaneKnobs(false);
     }
   }, {
     key: 'render',

--- a/dist/components/types/Array.js
+++ b/dist/components/types/Array.js
@@ -48,8 +48,8 @@ var styles = {
   color: '#555'
 };
 
-var ArrayType = function (_React$Component) {
-  (0, _inherits3.default)(ArrayType, _React$Component);
+var ArrayType = function (_React$PureComponent) {
+  (0, _inherits3.default)(ArrayType, _React$PureComponent);
 
   function ArrayType() {
     (0, _classCallCheck3.default)(this, ArrayType);
@@ -75,7 +75,7 @@ var ArrayType = function (_React$Component) {
     }
   }]);
   return ArrayType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 ArrayType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/components/types/Boolean.js
+++ b/dist/components/types/Boolean.js
@@ -41,8 +41,8 @@ var styles = {
   color: '#555'
 };
 
-var BooleanType = function (_React$Component) {
-  (0, _inherits3.default)(BooleanType, _React$Component);
+var BooleanType = function (_React$PureComponent) {
+  (0, _inherits3.default)(BooleanType, _React$PureComponent);
 
   function BooleanType() {
     (0, _classCallCheck3.default)(this, BooleanType);
@@ -72,7 +72,7 @@ var BooleanType = function (_React$Component) {
     }
   }]);
   return BooleanType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 BooleanType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/components/types/Color.js
+++ b/dist/components/types/Color.js
@@ -54,8 +54,8 @@ var styles = {
   }
 };
 
-var ColorType = function (_React$Component) {
-  (0, _inherits3.default)(ColorType, _React$Component);
+var ColorType = function (_React$PureComponent) {
+  (0, _inherits3.default)(ColorType, _React$PureComponent);
 
   function ColorType(props) {
     (0, _classCallCheck3.default)(this, ColorType);
@@ -64,6 +64,7 @@ var ColorType = function (_React$Component) {
 
     _this.handleClick = _this.handleClick.bind(_this);
     _this.onWindowMouseDown = _this.onWindowMouseDown.bind(_this);
+    _this.onChange = _this.onChange.bind(_this);
     _this.state = {
       displayColorPicker: false
     };
@@ -98,13 +99,16 @@ var ColorType = function (_React$Component) {
       });
     }
   }, {
+    key: 'onChange',
+    value: function onChange(color) {
+      this.props.onChange(color.hex);
+    }
+  }, {
     key: 'render',
     value: function render() {
       var _this2 = this;
 
-      var _props = this.props,
-          knob = _props.knob,
-          _onChange = _props.onChange;
+      var knob = this.props.knob;
 
       var colorStyle = {
         width: 'auto',
@@ -113,6 +117,7 @@ var ColorType = function (_React$Component) {
         margin: 5,
         background: knob.value
       };
+
       return _react2.default.createElement(
         'div',
         { id: knob.name },
@@ -126,15 +131,13 @@ var ColorType = function (_React$Component) {
           { style: styles.popover, ref: function ref(e) {
               _this2.popover = e;
             } },
-          _react2.default.createElement(_reactColor.SketchPicker, { color: knob.value, onChange: function onChange(color) {
-              return _onChange(color.hex);
-            } })
+          _react2.default.createElement(_reactColor.SketchPicker, { color: knob.value, onChange: this.onChange })
         ) : null
       );
     }
   }]);
   return ColorType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 ColorType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/components/types/Date/index.js
+++ b/dist/components/types/Date/index.js
@@ -47,8 +47,8 @@ var customStyle = '\n  .rdt input {\n    outline: 0;\n    width: 100%;\n    bord
 (0, _insertCss2.default)(_styles2.default);
 (0, _insertCss2.default)(customStyle);
 
-var DateType = function (_React$Component) {
-  (0, _inherits3.default)(DateType, _React$Component);
+var DateType = function (_React$PureComponent) {
+  (0, _inherits3.default)(DateType, _React$PureComponent);
 
   function DateType() {
     (0, _classCallCheck3.default)(this, DateType);
@@ -77,7 +77,7 @@ var DateType = function (_React$Component) {
     }
   }]);
   return DateType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 DateType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/components/types/Number.js
+++ b/dist/components/types/Number.js
@@ -44,8 +44,8 @@ var styles = {
   color: '#444'
 };
 
-var NumberType = function (_React$Component) {
-  (0, _inherits3.default)(NumberType, _React$Component);
+var NumberType = function (_React$PureComponent) {
+  (0, _inherits3.default)(NumberType, _React$PureComponent);
 
   function NumberType(props) {
     (0, _classCallCheck3.default)(this, NumberType);
@@ -112,7 +112,7 @@ var NumberType = function (_React$Component) {
     }
   }]);
   return NumberType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 NumberType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/components/types/Object.js
+++ b/dist/components/types/Object.js
@@ -60,8 +60,8 @@ var styles = {
   fontFamily: 'monospace'
 };
 
-var ObjectType = function (_React$Component) {
-  (0, _inherits3.default)(ObjectType, _React$Component);
+var ObjectType = function (_React$PureComponent) {
+  (0, _inherits3.default)(ObjectType, _React$PureComponent);
 
   function ObjectType() {
     var _ref;
@@ -144,7 +144,7 @@ var ObjectType = function (_React$Component) {
     }
   }]);
   return ObjectType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 ObjectType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/components/types/Select.js
+++ b/dist/components/types/Select.js
@@ -48,8 +48,8 @@ var styles = {
   color: '#555'
 };
 
-var SelectType = function (_React$Component) {
-  (0, _inherits3.default)(SelectType, _React$Component);
+var SelectType = function (_React$PureComponent) {
+  (0, _inherits3.default)(SelectType, _React$PureComponent);
 
   function SelectType() {
     (0, _classCallCheck3.default)(this, SelectType);
@@ -112,7 +112,7 @@ var SelectType = function (_React$Component) {
     }
   }]);
   return SelectType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 SelectType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/components/types/Text.js
+++ b/dist/components/types/Text.js
@@ -48,8 +48,8 @@ var styles = {
   color: '#555'
 };
 
-var TextType = function (_React$Component) {
-  (0, _inherits3.default)(TextType, _React$Component);
+var TextType = function (_React$PureComponent) {
+  (0, _inherits3.default)(TextType, _React$PureComponent);
 
   function TextType() {
     (0, _classCallCheck3.default)(this, TextType);
@@ -76,7 +76,7 @@ var TextType = function (_React$Component) {
     }
   }]);
   return TextType;
-}(_react2.default.Component);
+}(_react2.default.PureComponent);
 
 TextType.propTypes = {
   knob: _react2.default.PropTypes.object,

--- a/dist/index.js
+++ b/dist/index.js
@@ -94,7 +94,9 @@ function withKnobs(storyFn, context) {
   return manager.wrapStory(channel, storyFn, context);
 }
 
-function withKnobsOptions(options) {
+function withKnobsOptions() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
   return function () {
     var channel = _storybookAddons2.default.getChannel();
     channel.emit('addon:knobs:setOptions', options);

--- a/dist/index.js
+++ b/dist/index.js
@@ -95,8 +95,10 @@ function withKnobs(storyFn, context) {
 }
 
 function withKnobsOptions(options) {
-  var channel = _storybookAddons2.default.getChannel();
-  channel.emit('addon:knobs:setOptions', options);
+  return function () {
+    var channel = _storybookAddons2.default.getChannel();
+    channel.emit('addon:knobs:setOptions', options);
 
-  return withKnobs;
+    return withKnobs.apply(undefined, arguments);
+  };
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -18,6 +18,7 @@ exports.select = select;
 exports.array = array;
 exports.date = date;
 exports.withKnobs = withKnobs;
+exports.withKnobsOptions = withKnobsOptions;
 
 var _storybookAddons = require('@kadira/storybook-addons');
 
@@ -91,4 +92,11 @@ function date(name) {
 function withKnobs(storyFn, context) {
   var channel = _storybookAddons2.default.getChannel();
   return manager.wrapStory(channel, storyFn, context);
+}
+
+function withKnobsOptions(options) {
+  var channel = _storybookAddons2.default.getChannel();
+  channel.emit('addon:knobs:setOptions', options);
+
+  return withKnobs;
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "babel-runtime": "^6.5.0",
     "deep-equal": "^1.0.1",
     "insert-css": "^1.0.0",
+    "lodash.debounce": "^4.0.8",
     "moment": "^2.15.0",
     "react-color": "^2.4.3",
     "react-datetime": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "deep-equal": "^1.0.1",
     "insert-css": "^1.0.0",
     "lodash.debounce": "^4.0.8",
+    "lodash.isequal": "^4.5.0",
     "moment": "^2.15.0",
     "react-color": "^2.4.3",
     "react-datetime": "^2.6.0",

--- a/src/KnobManager.js
+++ b/src/KnobManager.js
@@ -65,11 +65,11 @@ export default class KnobManager {
       return;
     }
     this.calling = true;
-
+    const timestamp = +new Date();
     setTimeout(() => {
       this.calling = false;
       // emit to the channel and trigger a panel re-render
-      this.channel.emit('addon:knobs:setKnobs', this.knobStore.getAll());
+      this.channel.emit('addon:knobs:setKnobs', { knobs: this.knobStore.getAll(), timestamp });
     }, PANEL_UPDATE_INTERVAL);
   }
 }

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -78,7 +78,6 @@ export default class Panel extends React.Component {
     const { api, channel } = this.props;
 
     if (this.lastEdit <= timestamp) {
-      this.lastEdit = getTimestamp();
 
       Object.keys(knobs).forEach((name) => {
         const knob = knobs[name];

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -49,6 +49,7 @@ export default class Panel extends React.Component {
     this.setOptions = this.setOptions.bind(this);
 
     this.state = { knobs: {} };
+    this.options = {};
 
     this.lastEdit = getTimestamp();
     this.loadedFromUrl = false;
@@ -62,8 +63,9 @@ export default class Panel extends React.Component {
 
   setOptions(options = {
     debounce: false,
-    leading: false, //first change is istant
+    timestamps: false,
   }) {
+    this.options = options;
     if (options.debounce) {
       this.emitChange = debounce(
         this.emitChange,
@@ -77,8 +79,7 @@ export default class Panel extends React.Component {
     const queryParams = {};
     const { api, channel } = this.props;
 
-    if (this.lastEdit <= timestamp) {
-
+    if (!this.options.timestamps || this.lastEdit <= timestamp) {
       Object.keys(knobs).forEach((name) => {
         const knob = knobs[name];
         // For the first time, get values from the URL and set them.

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -58,7 +58,7 @@ export default class Panel extends React.Component {
     leading: false, //first change is istant
   }) {
     if (options.debounce) {
-      this.emitChange = debounce(this.emitChange, 450, {leading: options.leading});
+      this.emitChange = debounce(this.emitChange, options.debounce, {leading: options.leading});
     }
   }
 

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -79,7 +79,7 @@ export default class Panel extends React.Component {
     const queryParams = {};
     const { api, channel } = this.props;
 
-    if (!this.options.timestamps || this.lastEdit <= timestamp) {
+    if (!this.options.timestamps || !timestamp || this.lastEdit <= timestamp) {
       Object.keys(knobs).forEach((name) => {
         const knob = knobs[name];
         // For the first time, get values from the URL and set them.

--- a/src/components/PropField.js
+++ b/src/components/PropField.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import TypeMap from './types';
+import isEqual from 'lodash.isequal';
 
 const InvalidType = () => (<span>Invalid Type</span>);
 
@@ -33,18 +34,22 @@ stylesheet.checkbox = {
   width: 'auto',
 };
 
-export default class PropField extends React.Component {
+export default class PropField extends React.PureComponent {
   constructor(props) {
     super(props);
-    this._onChange = this.onChange.bind(this);
+    this._onChange = this._onChange.bind(this);
   }
 
-  onChange(e) {
-    this.props.onChange(e.target.value);
+  _onChange(value) {
+    this.props.onChange(this.props.name, this.props.type, value);
+  }
+
+  shouldComponentUpdate(newProps) {
+    return !isEqual(this.props.knob, newProps.knob);
   }
 
   render() {
-    const { onChange, knob } = this.props;
+    const { knob } = this.props;
 
     let InputType = TypeMap[knob.type] || InvalidType;
 
@@ -55,7 +60,7 @@ export default class PropField extends React.Component {
         </label>
         <InputType
           knob={knob}
-          onChange={onChange}
+          onChange={this._onChange}
         />
       </div>
     );

--- a/src/components/PropForm.js
+++ b/src/components/PropForm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropField from './PropField';
 
 const stylesheet = {
@@ -16,7 +15,7 @@ const stylesheet = {
   },
 };
 
-export default class propForm extends React.Component {
+export default class propForm extends React.PureComponent {
   constructor() {
     super();
     this._onFieldChange = this.onFieldChange.bind(this);
@@ -28,7 +27,7 @@ export default class propForm extends React.Component {
   }
 
   render() {
-    const knobs = this.props.knobs;
+    const { knobs } = this.props;
 
     return (
       <form style={stylesheet.propForm}>
@@ -39,7 +38,7 @@ export default class propForm extends React.Component {
             type={knob.type}
             value={knob.value}
             knob={knob}
-            onChange={this._onFieldChange.bind(null, knob.name, knob.type)}
+            onChange={this._onFieldChange}
           />
         ))}
       </form>

--- a/src/components/WrapStory.js
+++ b/src/components/WrapStory.js
@@ -32,9 +32,9 @@ export default class WrapStory extends React.Component {
     this.props.knobStore.unsubscribe(this.setPaneKnobs);
   }
 
-  setPaneKnobs() {
+  setPaneKnobs(timestamp = +new Date()) {
     const { channel, knobStore } = this.props;
-    channel.emit('addon:knobs:setKnobs', { knobs: knobStore.getAll(), timestamp: +new Date() });
+    channel.emit('addon:knobs:setKnobs', { knobs: knobStore.getAll(), timestamp});
   }
 
   knobChanged(change) {
@@ -51,7 +51,7 @@ export default class WrapStory extends React.Component {
     const { knobStore, storyFn, context } = this.props;
     knobStore.reset();
     this.setState({ storyContent: storyFn(context) });
-    this.setPaneKnobs();
+    this.setPaneKnobs(false);
   }
 
   render() {

--- a/src/components/WrapStory.js
+++ b/src/components/WrapStory.js
@@ -34,7 +34,7 @@ export default class WrapStory extends React.Component {
 
   setPaneKnobs() {
     const { channel, knobStore } = this.props;
-    channel.emit('addon:knobs:setKnobs', knobStore.getAll());
+    channel.emit('addon:knobs:setKnobs', { knobs: knobStore.getAll(), timestamp: +new Date() });
   }
 
   knobChanged(change) {

--- a/src/components/tests/Panel.js
+++ b/src/components/tests/Panel.js
@@ -51,7 +51,7 @@ describe('Panel', () => {
         },
       };
 
-      setKnobsHandler(knobs);
+      setKnobsHandler({ knobs, timestamp: +new Date() });
       const knobFromUrl = {
         name: 'foo',
         value: testQueryParams['knob-foo'],
@@ -102,7 +102,7 @@ describe('Panel', () => {
       // Make it act like that url params are already checked
       wrapper.instance().loadedFromUrl = true;
 
-      setKnobsHandler(knobs);
+      setKnobsHandler({ knobs, timestamp: +new Date() });
       const knobFromStory = {
         'knob-foo': knobs.foo.value,
         'knob-baz': knobs.baz.value,

--- a/src/components/types/Array.js
+++ b/src/components/types/Array.js
@@ -15,7 +15,7 @@ const styles = {
   color: '#555',
 };
 
-class ArrayType extends React.Component {
+class ArrayType extends React.PureComponent {
   render() {
     const { knob, onChange } = this.props;
     return (

--- a/src/components/types/Boolean.js
+++ b/src/components/types/Boolean.js
@@ -11,7 +11,7 @@ const styles = {
   color: '#555',
 };
 
-class BooleanType extends React.Component {
+class BooleanType extends React.PureComponent {
   render() {
     const { knob, onChange } = this.props;
 

--- a/src/components/types/Color.js
+++ b/src/components/types/Color.js
@@ -23,11 +23,12 @@ const styles = {
   },
 };
 
-class ColorType extends React.Component {
+class ColorType extends React.PureComponent {
   constructor(props) {
     super(props);
     this.handleClick = this.handleClick.bind(this);
     this.onWindowMouseDown = this.onWindowMouseDown.bind(this);
+    this.onChange = this.onChange.bind(this);
     this.state = {
       displayColorPicker: false,
     };
@@ -55,8 +56,12 @@ class ColorType extends React.Component {
     });
   }
 
+  onChange(color) {
+    this.props.onChange(color.hex);
+  }
+
   render() {
-    const { knob, onChange } = this.props;
+    const { knob } = this.props;
     const colorStyle = {
       width: 'auto',
       height: '20px',
@@ -64,6 +69,7 @@ class ColorType extends React.Component {
       margin: 5,
       background: knob.value,
     };
+
     return (
       <div id={knob.name}>
         <div style={ styles.swatch } onClick={ this.handleClick }>
@@ -71,7 +77,7 @@ class ColorType extends React.Component {
         </div>
         { this.state.displayColorPicker ? (
           <div style={ styles.popover } ref={(e) => {this.popover = e;}}>
-            <SketchPicker color={ knob.value } onChange={ color => onChange(color.hex) } />
+            <SketchPicker color={ knob.value } onChange={ this.onChange } />
           </div>
         ) : null }
       </div>

--- a/src/components/types/Date/index.js
+++ b/src/components/types/Date/index.js
@@ -20,7 +20,7 @@ const customStyle = `
 insertCss(style);
 insertCss(customStyle);
 
-class DateType extends React.Component {
+class DateType extends React.PureComponent {
   render() {
     const { knob, onChange } = this.props;
     return (

--- a/src/components/types/Number.js
+++ b/src/components/types/Number.js
@@ -15,7 +15,7 @@ const styles = {
 };
 
 
-class NumberType extends React.Component {
+class NumberType extends React.PureComponent {
 
   constructor(props) {
     super(props);

--- a/src/components/types/Object.js
+++ b/src/components/types/Object.js
@@ -16,7 +16,7 @@ const styles = {
   fontFamily: 'monospace',
 };
 
-class ObjectType extends React.Component {
+class ObjectType extends React.PureComponent {
   constructor(...args) {
     super(...args);
     this.state = {};

--- a/src/components/types/Select.js
+++ b/src/components/types/Select.js
@@ -14,7 +14,7 @@ const styles = {
   color: '#555',
 };
 
-class SelectType extends React.Component {
+class SelectType extends React.PureComponent {
   _makeOpt(key, val) {
     const opts = {
       key,

--- a/src/components/types/Text.js
+++ b/src/components/types/Text.js
@@ -15,7 +15,7 @@ const styles = {
   color: '#555',
 };
 
-class TextType extends React.Component {
+class TextType extends React.PureComponent {
   render() {
     const { knob, onChange } = this.props;
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,11 +60,11 @@ export function withKnobs(storyFn, context) {
   return manager.wrapStory(channel, storyFn, context);
 }
 
-export function withKnobsOptions(options) {
+export function withKnobsOptions(options = {}) {
   return (...args) => {
     const channel = addons.getChannel();
     channel.emit('addon:knobs:setOptions', options);
 
     return withKnobs(...args);
-  }
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,10 @@ export function withKnobs(storyFn, context) {
 }
 
 export function withKnobsOptions(options) {
-  const channel = addons.getChannel();
-  channel.emit('addon:knobs:setOptions', options);
+  return (...args) => {
+    const channel = addons.getChannel();
+    channel.emit('addon:knobs:setOptions', options);
 
-  return withKnobs;
+    return withKnobs(...args);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,3 +59,10 @@ export function withKnobs(storyFn, context) {
   const channel = addons.getChannel();
   return manager.wrapStory(channel, storyFn, context);
 }
+
+export function withKnobsOptions(options) {
+  const channel = addons.getChannel();
+  channel.emit('addon:knobs:setOptions', options);
+
+  return withKnobs;
+}

--- a/storybook-addon-knobs.d.ts
+++ b/storybook-addon-knobs.d.ts
@@ -39,4 +39,4 @@ interface IWrapStoryProps {
   initialContent?: Object;
 }
 
-export function withKnobsOptions(options: Object): withKnobs;
+export function withKnobsOptions(options: Object): (storyFn: Function, context: StoryContext) => withKnobs;

--- a/storybook-addon-knobs.d.ts
+++ b/storybook-addon-knobs.d.ts
@@ -11,7 +11,7 @@ interface StoryContext {
 }
 
 interface withKnobs {
-    (storyFn: Function, context: StoryContext): React.ReactElement<IWrapStoryProps>;
+	(storyFn: Function, context: StoryContext): React.ReactElement<IWrapStoryProps>;
 }
 
 export function knob<T>(name: string, options: KnobOption<T>): T;

--- a/storybook-addon-knobs.d.ts
+++ b/storybook-addon-knobs.d.ts
@@ -10,6 +10,10 @@ interface StoryContext {
 	story: string,
 }
 
+interface withKnobs {
+    (storyFn: Function, context: StoryContext): React.ReactElement<IWrapStoryProps>;
+}
+
 export function knob<T>(name: string, options: KnobOption<T>): T;
 
 export function text(name: string, value: string | null): string;
@@ -35,4 +39,4 @@ interface IWrapStoryProps {
   initialContent?: Object;
 }
 
-export function withKnobs(storyFn: Function, context: StoryContext): React.ReactElement<IWrapStoryProps>;
+export function withKnobsOptions(options: Object): withKnobs;


### PR DESCRIPTION
# Fixing performance issues
## Added timestamps to setKnobs event.
If user is typing, his typing shouldn't be interrupted by randomly happening setKnobs action. Now setKnobs will actually do something only after user finishes typing.

### Example
```
const {withKnobsOptions} = require('storybook-addon-knobs');
story.addDecorator(withKnobsOptions({timestamps: true}));
```


## Added ability to pass debounce option when adding decorator
As #92 said we needed an option to add debouncing to knob changes.
I added an option to pass options when adding decorator to story.

### Example
```
const {withKnobsOptions} = require('storybook-addon-knobs');
//debounce options are wait and leading, same as in lodash.
story.addDecorator(withKnobsOptions({debounce: { wait: 100, leading: true}}));
```

## Fixing performance of field components
Fields are now extending React.PureComponent, also added deep checking if fields actually need to rerender. Didn't check performance with debug tools, but it feels smoother.

## Things to note
* Added loadash.debounce package as a dependency.
* Added lodash.isequal package as a dependency.
* Two tests changed, added timestamps so they would work.